### PR TITLE
Agrega columna buscable de número de cierre (ID) en tabla de Cierres

### DIFF
--- a/app/Filament/Ventas/Resources/CierreResource.php
+++ b/app/Filament/Ventas/Resources/CierreResource.php
@@ -101,6 +101,10 @@ class CierreResource extends Resource
 
         return $table
             ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('No. Cierre')
+                    ->searchable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('bodega.bodega')
                     ->label('Bodega')
                     ->numeric()


### PR DESCRIPTION
Permite buscar y ordenar cierres por su ID, ya que antes no había forma de localizar un cierre específico por número.